### PR TITLE
fix: Issue with example-app compilation, script rework, minor cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,25 @@
 {
   "name": "platform",
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "nohoist": [
+      "example-app/@angular-redux/store",
+      "example-app/@angular-redux/form",
+      "example-app/@angular-redux/router",
+      "example-app/ng-packagr"
+    ]
+  },
   "scripts": {
     "build": "npm-run-all build:*",
-    "build:store": "ng-packagr -p packages/store",
-    "build:form": "ng-packagr -p packages/form",
-    "build:router": "ng-packagr -p packages/router",
-    "release:canary": "lerna publish --canary --npm-tag next --npm-client npm",
+    "build:store": "yarn workspace store build",
+    "build:form": "yarn workspace form build",
+    "build:router": "yarn workspace router build",
+    "release:canary": "lerna publish --canary --contents dist --dist-tag next",
     "release:stable": "lerna version",
-    "release:stable:ci": "lerna publish from-git",
+    "release:stable:ci": "lerna publish from-git --contents dist",
     "clean": "npm-run-all -p clean:*",
     "clean:deps": "npm-run-all -p clean:deps:*",
     "clean:deps:workspace": "rimraf node_modules",
@@ -26,7 +34,8 @@
     "test:ci": "jest --coverage --ci --maxWorkers=2",
     "test:watch": "jest --watch",
     "commit": "commit",
-    "prettier": "prettier --write \"**/*.*(ts|js|css|scss|json|md)\""
+    "prettier": "prettier --write \"**/*.*(ts|js|css|scss|json|md)\"",
+    "run:app": ""
   },
   "lint-staged": {
     "*.{ts,js,css,scss,json,md}": [

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "scripts": {
     "build": "npm-run-all build:*",
-    "build:store": "yarn workspace store build",
-    "build:form": "yarn workspace form build",
-    "build:router": "yarn workspace router build",
+    "build:store": "yarn workspace @angular-redux/store build",
+    "build:form": "yarn workspace @angular-redux/form build",
+    "build:router": "yarn workspace @angular-redux/router build",
     "release:canary": "lerna publish --canary --contents dist --dist-tag next",
     "release:stable": "lerna version",
     "release:stable:ci": "lerna publish from-git --contents dist",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:watch": "jest --watch",
     "commit": "commit",
     "prettier": "prettier --write \"**/*.*(ts|js|css|scss|json|md)\"",
-    "run:app": ""
+    "run:app": "yarn workspace example-app bootstrap && yarn workspace example-app start"
   },
   "lint-staged": {
     "*.{ts,js,css,scss,json,md}": [

--- a/packages/example-app/README.md
+++ b/packages/example-app/README.md
@@ -10,6 +10,10 @@ application.
 - [@angular-redux/form](/packages/form) Time travel with Angular forms
 - [Redux DevTools Chrome Extension](https://github.com/zalmoxisus/redux-devtools-extension)
 
+## Bootstrapping
+
+Before being able to run the app, you will need to bootstrap the workspace dependencies linked by yarn. This can be done using the command `yarn bootstrap`.
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
@@ -30,6 +34,10 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 Before running the tests make sure you are serving the app via `ng serve`.
+
+## Using the folder as a standalone
+
+The versions included in `package.json` for the `@angular-redux` dependencies are linked using **yarn workspaces** and will need to be changed to a _latest_ or _next_ version if you want to detach the app as a standalone.
 
 ## Further help
 

--- a/packages/example-app/package.json
+++ b/packages/example-app/package.json
@@ -9,7 +9,11 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "bootstrap": "npm-run-all bootstrap:*",
+    "bootstrap:store": "npm explore @angular-redux/store -- npm run build",
+    "bootstrap:form": "npm explore @angular-redux/form -- npm run build",
+    "bootstrap:router": "npm explore @angular-redux/router -- npm run build"
   },
   "engines": {
     "node": ">=8"

--- a/packages/example-app/src/app/store/reducers.ts
+++ b/packages/example-app/src/app/store/reducers.ts
@@ -5,13 +5,12 @@ import { combineReducers } from 'redux';
 import { createAnimalAPIReducer } from '../animals/api/reducer';
 import { ANIMAL_TYPES } from '../animals/model';
 
-const elephant = createAnimalAPIReducer(ANIMAL_TYPES.ELEPHANT);
 // Define the global store shape by combining our application's
 // reducers together into a given structure.
 export const rootReducer = composeReducers(
   defaultFormReducer<unknown>(),
   combineReducers({
-    elephant,
+    elephant: createAnimalAPIReducer(ANIMAL_TYPES.ELEPHANT),
     lion: createAnimalAPIReducer(ANIMAL_TYPES.LION),
     router: routerReducer,
   }),

--- a/packages/example-app/src/tsconfig.app.json
+++ b/packages/example-app/src/tsconfig.app.json
@@ -1,26 +1,8 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "sourceMap": true,
-    "declaration": false,
-    "moduleResolution": "node",
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": ["es2016", "dom"],
     "outDir": "../out-tsc/app",
-    "target": "es5",
-    "module": "es2015",
-    "baseUrl": ".",
-    "types": [],
-    "paths": {
-      "@angular/*": ["../node_modules/@angular/*"]
-    },
-
-    // Causes problems for @Outputs. See https://github.com/angular/angular/issues/17131.
-    // "noUnusedParameters": true,
-    // "noUnusedLocals": true,
-
-    "forceConsistentCasingInFileNames": true,
-    "pretty": true
+    "types": []
   },
   "exclude": ["test.ts", "**/*.spec.ts"]
 }

--- a/packages/example-app/tsconfig.json
+++ b/packages/example-app/tsconfig.json
@@ -11,10 +11,9 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "es5",
-    "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"],
     "paths": {
-      "@angular/*": ["../node_modules/@angular/*"]
+      "@angular-redux/*": ["node_modules/@angular-redux/*/dist"]
     },
 
     // Causes problems for @Outputs with AoT.

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -5,6 +5,10 @@
   "author": "Chris Bond",
   "license": "MIT",
   "homepage": "https://github.com/angular-redux/platform",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "ng-packagr -p ."
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/angular-redux/platform.git"
@@ -33,6 +37,5 @@
   },
   "dependencies": {
     "immutable": "^4.0.0-rc.12"
-  },
-  "main": "src/index.ts"
+  }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -5,6 +5,10 @@
   "author": "Dag Stuan",
   "license": "MIT",
   "homepage": "https://github.com/angular-redux/platform",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "ng-packagr -p ."
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/angular-redux/platform.git"
@@ -32,6 +36,5 @@
     "@angular/router": "^7.0.0",
     "redux": "^4.0.0",
     "rxjs": "^6.0.0"
-  },
-  "main": "src/index.ts"
+  }
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -19,7 +19,6 @@ export class NgReduxRouter {
   constructor(
     private router: Router,
     private ngRedux: NgRedux<any>,
-    // private applicationRef: ApplicationRef,
     private location: Location,
   ) {}
 

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -5,6 +5,10 @@
   "author": "William Buchwalter <wbuchwalter@gmail.com> (http://github.com/wbuchwalter)",
   "license": "MIT",
   "homepage": "https://github.com/angular-redux/platform",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "ng-packagr -p ."
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/angular-redux/platform.git"
@@ -32,6 +36,5 @@
   },
   "devDependencies": {
     "redux-devtools-extension": "^2.13.7"
-  },
-  "main": "src/index.ts"
+  }
 }


### PR DESCRIPTION
- Fix an issue with the example app refusing to compile workspace deps by not hoisting packages in the example-app folder and adding a bootstrap step to be run before serving/building
- Publish only dist folder for packages rather than root (with source code)
- Move build scripts into child packages
- Remove artifacts created during the upgrade process
- Clean up some of the config files