### PR TITLE
test(form): add export contract tests

### DIFF
--- a/packages/form/src/exports.spec.ts
+++ b/packages/form/src/exports.spec.ts
@@ -1,0 +1,79 @@
+import {
+  composeReducers,
+  ConnectArrayDirective,
+  ConnectArrayTemplate,
+  ConnectBase,
+  ConnectDirective,
+  defaultFormReducer,
+  FORM_CHANGED,
+  FormException,
+  FormStore,
+  formStoreFactory,
+  NgReduxFormConnectArrayModule,
+  NgReduxFormConnectModule,
+  NgReduxFormModule,
+  provideReduxForms,
+  ReactiveConnectDirective,
+} from './index';
+
+describe('The @angular-redux/form package exports', () => {
+  it('should contain the composeReducers function', () => {
+    expect(composeReducers).toBeDefined();
+  });
+
+  it('should contain the ConnectArrayDirective class', () => {
+    expect(ConnectArrayDirective).toBeDefined();
+  });
+
+  it('should contain the ConnectArrayTemplate class', () => {
+    expect(ConnectArrayTemplate).toBeDefined();
+  });
+
+  it('should contain the ConnectBase class', () => {
+    expect(ConnectBase).toBeDefined();
+  });
+
+  it('should contain the ConnectDirective class', () => {
+    expect(ConnectDirective).toBeDefined();
+  });
+
+  it('should contain the defaultFormReducer function', () => {
+    expect(defaultFormReducer).toBeDefined();
+  });
+
+  it('should contain the FORM_CHANGED const', () => {
+    expect(FORM_CHANGED).toBeDefined();
+  });
+
+  it('should contain the FormException class', () => {
+    expect(FormException).toBeDefined();
+  });
+
+  it('should contain the FormStore class', () => {
+    expect(FormStore).toBeDefined();
+  });
+
+  it('should contain the formStoreFactory function', () => {
+    expect(formStoreFactory).toBeDefined();
+  });
+
+  it('should contain the NgReduxFormConnectArrayModule class', () => {
+    expect(NgReduxFormConnectArrayModule).toBeDefined();
+  });
+
+  it('should contain the NgReduxFormConnectModule class', () => {
+    expect(NgReduxFormConnectModule).toBeDefined();
+  });
+
+  it('should contain the NgReduxFormModule class', () => {
+    expect(NgReduxFormModule).toBeDefined();
+  });
+
+  it('should contain the provideReduxForms function', () => {
+    expect(provideReduxForms).toBeDefined();
+  });
+
+  it('should contain the ReactiveConnectDirective class', () => {
+    expect(ReactiveConnectDirective).toBeDefined();
+  });
+});

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -1,13 +1,39 @@
-export * from './compose-reducers';
-export * from './form-reducer';
-export * from './form-exception';
-export * from './form-store';
-export * from './configure';
-export * from './connect/connect-base';
-export * from './connect/connect-reactive';
-export * from './connect/connect.directive';
-export * from './connect/connect.module';
-export * from './connect-array/connect-array-template';
-export * from './connect-array/connect-array.directive';
-export * from './connect-array/connect-array.module';
-export * from './module';
+import { composeReducers } from './compose-reducers';
+import { provideReduxForms } from './configure';
+import { FormException } from './form-exception';
+import { defaultFormReducer } from './form-reducer';
+import { AbstractStore, FORM_CHANGED, FormStore } from './form-store';
+import { formStoreFactory, NgReduxFormModule } from './module';
+
+import { ConnectBase, ControlPair } from './connect/connect-base';
+import { ReactiveConnectDirective } from './connect/connect-reactive';
+import { ConnectDirective } from './connect/connect.directive';
+import { NgReduxFormConnectModule } from './connect/connect.module';
+
+import { ConnectArrayTemplate } from './connect-array/connect-array-template';
+import { ConnectArrayDirective } from './connect-array/connect-array.directive';
+import { NgReduxFormConnectArrayModule } from './connect-array/connect-array.module';
+
+// Warning: don't do this:
+//  export * from './foo'
+// ... because it breaks rollup. See
+// https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module
+export {
+  AbstractStore,
+  composeReducers,
+  ConnectArrayDirective,
+  ConnectArrayTemplate,
+  ConnectBase,
+  ConnectDirective,
+  ControlPair,
+  defaultFormReducer,
+  FORM_CHANGED,
+  FormException,
+  FormStore,
+  formStoreFactory,
+  NgReduxFormConnectArrayModule,
+  NgReduxFormConnectModule,
+  NgReduxFormModule,
+  provideReduxForms,
+  ReactiveConnectDirective,
+};


### PR DESCRIPTION
Also adjusts the main export barrel file to explicitly export library members