### PR TITLE
update NgRedux class to work with redux 4.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "platform",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ng-packagr": "4.6.0",
     "npm-run-all": "4.1.5",
     "prettier": "1.15.3",
-    "redux": "4.1.2",
+    "redux": "^4.1.2",
     "rimraf": "2.6.3",
     "rxjs": "6.3.3",
     "tsickle": "0.34.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ng-packagr": "4.6.0",
     "npm-run-all": "4.1.5",
     "prettier": "1.15.3",
-    "redux": "4.0.1",
+    "redux": "4.1.2",
     "rimraf": "2.6.3",
     "rxjs": "6.3.3",
     "tsickle": "0.34.0",

--- a/packages/store/src/components/ng-redux.ts
+++ b/packages/store/src/components/ng-redux.ts
@@ -2,12 +2,13 @@ import {
   AnyAction,
   Dispatch,
   Middleware,
+  Observable,
   Reducer,
   Store,
   StoreEnhancer,
   Unsubscribe,
 } from 'redux';
-import { Observable } from 'rxjs';
+import { Observable as rxjsObservable } from 'rxjs';
 import { ObservableStore } from './observable-store';
 import { Comparator, PathSelector, Selector } from './selectors';
 
@@ -61,9 +62,11 @@ export abstract class NgRedux<RootState> implements ObservableStore<RootState> {
   abstract select: <SelectedType>(
     selector?: Selector<RootState, SelectedType>,
     comparator?: Comparator,
-  ) => Observable<SelectedType>;
+  ) => rxjsObservable<SelectedType>;
   abstract configureSubStore: <SubState>(
     basePath: PathSelector,
     localReducer: Reducer<SubState, AnyAction>,
   ) => ObservableStore<SubState>;
+
+  [Symbol.observable](): Observable<RootState>;
 }


### PR DESCRIPTION
package does not function with latest redux package due to missing the implementation of [Symbol.observable](): Observable<RootState>; from the store interface